### PR TITLE
fix: null changes error

### DIFF
--- a/.github/workflows/synchronize-to-dtk6.yml
+++ b/.github/workflows/synchronize-to-dtk6.yml
@@ -55,6 +55,17 @@ jobs:
             rsync -avz --delete --exclude=.git --exclude=.obs --exclude=debian --exclude=archlinux --exclude=rpm ${{ github.workspace }}/source/ ${{ github.workspace }}/dest/
           fi
           cd ${{ github.workspace }}/dest
+          difference=$(git diff)
+          if [[ ! -z ${difference} ]]; then
+            echo "has_diff=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_diff=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit changes to ${{ inputs.dest_repo }}
+        if: steps.rsync.outputs.has_diff
+        run: |
+          cd ${{ github.workspace }}/dest
           git add :/
           git commit \
           -m "sync: from ${{ github.repository }}" \

--- a/.github/workflows/synchronize-to-dtk6.yml
+++ b/.github/workflows/synchronize-to-dtk6.yml
@@ -50,9 +50,9 @@ jobs:
           cd ${{ github.workspace }}/source
           version=$(git describe)
           if [[ -f ${{ github.workspace }}/source/.syncexclude ]]; then
-            rsync -avz --delete --exclude=.git --exclude=.obs --exclude=debian --exclude=archlinux --exclude=rpm --exclude-from=.syncexclude ${{ github.workspace }}/source ${{ github.workspace }}/dest
+            rsync -avz --delete --exclude=.git --exclude=.github --exclude=.obs --exclude=debian --exclude=archlinux --exclude=rpm --exclude-from=.syncexclude ${{ github.workspace }}/source ${{ github.workspace }}/dest
           else
-            rsync -avz --delete --exclude=.git --exclude=.obs --exclude=debian --exclude=archlinux --exclude=rpm ${{ github.workspace }}/source/ ${{ github.workspace }}/dest/
+            rsync -avz --delete --exclude=.git --exclude=.github --exclude=.obs --exclude=debian --exclude=archlinux --exclude=rpm ${{ github.workspace }}/source/ ${{ github.workspace }}/dest/
           fi
           cd ${{ github.workspace }}/dest
           difference=$(git diff)


### PR DESCRIPTION
When there is no change after synchronizing(workflow triggered by
file changes ignored by .syncexclude). "git add" will generate an
error.

Log: fix null changes error
