### PR TITLE
fix: incorrect source repository

### DIFF
--- a/.github/workflows/synchronize-to-dtk6.yml
+++ b/.github/workflows/synchronize-to-dtk6.yml
@@ -5,6 +5,9 @@ on:
       dest_repo:
         type: string
         required: true
+      source_repo:
+        type: string
+        required: true
       source_ref:
         type: string
         required: true
@@ -22,12 +25,13 @@ jobs:
   sync-pull-request:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout source repository ${{ github.repository }}
+      - name: Checkout source repository ${{ inputs.source_repo }}
         uses: actions/checkout@v3
         with:
           token: ${{ env.GH_TOKEN }}
           ref: ${{ inputs.source_ref }}
           path: 'source'
+          repository: ${{ inputs.source_repo }}
           fetch-depth: 0
 
       - name: Checkout dest repository ${{ inputs.dest_repo }}


### PR DESCRIPTION
We should acquire repository full name from github pull request event. As synchronize-to-dtk6 is a reusable workflow, pull request event context may miss when this workflow is called. Pass source repository as a parameter.

Log: fix incorrect source repository