### PR TITLE
fix: lacking tag info in fork

### DIFF
--- a/.github/workflows/synchronize-to-dtk6.yml
+++ b/.github/workflows/synchronize-to-dtk6.yml
@@ -52,7 +52,6 @@ jobs:
           cd ${{ github.workspace }}/dest
           git checkout -B ${tbranch}
           cd ${{ github.workspace }}/source
-          version=$(git describe)
           if [[ -f ${{ github.workspace }}/source/.syncexclude ]]; then
             rsync -avzp --delete --exclude=.git --exclude=.github --exclude=.obs --exclude=debian --exclude=archlinux --exclude=rpm --exclude-from=.syncexclude ${{ github.workspace }}/source ${{ github.workspace }}/dest
           else
@@ -69,6 +68,10 @@ jobs:
       - name: Commit changes to ${{ inputs.dest_repo }}
         if: steps.rsync.outputs.has_diff
         run: |
+          cd ${{ github.workspace }}/source
+          git remote add self-upstream ${{ github.event.repository.clone_url }}
+          git fetch --all
+          version=$(git describe)
           cd ${{ github.workspace }}/dest
           git add :/
           git commit \


### PR DESCRIPTION
The source repository might be a fork of the repository the workflow runs
on, thus there is no version info (tags). Just add the original repository 
as upstream. Fetch all tags from the original repository.

Log: fix lacking tag info in the fork