### PR TITLE
fix: wrong params of rsync

### DIFF
--- a/.github/workflows/synchronize-to-dtk6.yml
+++ b/.github/workflows/synchronize-to-dtk6.yml
@@ -53,7 +53,7 @@ jobs:
           git checkout -B ${tbranch}
           cd ${{ github.workspace }}/source
           if [[ -f ${{ github.workspace }}/source/.syncexclude ]]; then
-            rsync -avzp --delete --exclude=.git --exclude=.github --exclude=.obs --exclude=debian --exclude=archlinux --exclude=rpm --exclude-from=.syncexclude ${{ github.workspace }}/source ${{ github.workspace }}/dest
+            rsync -avzp --delete --exclude=.git --exclude=.github --exclude=.obs --exclude=debian --exclude=archlinux --exclude=rpm --exclude-from=.syncexclude ${{ github.workspace }}/source/ ${{ github.workspace }}/dest/
           else
             rsync -avzp --delete --exclude=.git --exclude=.github --exclude=.obs --exclude=debian --exclude=archlinux --exclude=rpm ${{ github.workspace }}/source/ ${{ github.workspace }}/dest/
           fi
@@ -81,5 +81,5 @@ jobs:
           gh repo set-default ${{ inputs.dest_repo }}
           result=$(gh pr list --base master --head ${tbranch} --state open)
           if [[ -z $result ]]; then
-            gh pr create -B master -H ${tbranch} --fill -r linuxdeepin/dtk
+            gh pr create -B master -H ${tbranch} --fill
           fi

--- a/.github/workflows/synchronize-to-dtk6.yml
+++ b/.github/workflows/synchronize-to-dtk6.yml
@@ -69,23 +69,17 @@ jobs:
       - name: Commit changes to ${{ inputs.dest_repo }}
         if: steps.rsync.outputs.has_diff
         run: |
-          cd ${{ github.workspace }}/source
-          git remote add self-upstream ${{ github.event.repository.clone_url }}
-          git fetch --all
-          version=$(git describe)
           tbranch=${{ steps.rsync.outputs.tbranch }}
           cd ${{ github.workspace }}/dest
           git add :/
           git commit \
           -m "sync: from ${{ github.repository }}" \
           -m "Synchronize source files from ${{ github.repository }}." \
-          -m "Source-version: ${version}
-          Source-pull-request: https://github.com/${{ github.repository }}/pull/${{ inputs.pull_number }}"
+          -m "Source-pull-request: https://github.com/${{ github.repository }}/pull/${{ inputs.pull_number }}"
           git push -u -f origin ${tbranch}
           cd ${{ github.workspace }}/dest
           gh repo set-default ${{ inputs.dest_repo }}
           result=$(gh pr list --base master --head ${tbranch} --state open)
           if [[ -z $result ]]; then
-            gh pr create -B master -H ${tbranch} --title "sync: from ${{ github.repository }}" --body "Synchronize source files from ${{ github.repository }}.
-            Source-pull-request: https://github.com/${{ github.repository }}/pull/${{ inputs.pull_number }}"
+            gh pr create -B master -H ${tbranch} --fill -r linuxdeepin/dtk
           fi


### PR DESCRIPTION
Rsync should sync files not directories. Add slash to the path.

Log: fix wrong params of rsync
