### PR TITLE
fix: pull request head out of date

### DIFF
--- a/.github/workflows/synchronize-to-dtk6.yml
+++ b/.github/workflows/synchronize-to-dtk6.yml
@@ -52,6 +52,9 @@ jobs:
           cd ${{ github.workspace }}/dest
           git checkout -B ${tbranch}
           cd ${{ github.workspace }}/source
+          git remote add upstream "${{ github.event.repository.clone_url }}"
+          git fetch --all
+          git rebase upstream/master
           if [[ -f ${{ github.workspace }}/source/.syncexclude ]]; then
             rsync -avzp --delete --exclude=.git --exclude=.github --exclude=.obs --exclude=debian --exclude=archlinux --exclude=rpm --exclude-from=.syncexclude ${{ github.workspace }}/source/ ${{ github.workspace }}/dest/
           else


### PR DESCRIPTION
Pull request's head might be out of date. We must rebase it in advance to ensure we have the newest changes.

Log: fix pull request head out of date