### PR TITLE
chore: do not synchronize sync branch

### DIFF
--- a/.github/workflows/synchronize-to-dtk6.yml
+++ b/.github/workflows/synchronize-to-dtk6.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           git config --global user.name "deepin-ci-robot"
           git config --global user.email "packages@deepin.org"
-          tbranch="sync-${{ inputs.pull_number }}"
+          tbranch="sync-pr-${{ inputs.pull_number }}-nosync"
           set -x
           cd ${{ github.workspace }}/dest
           git checkout -B ${tbranch}


### PR DESCRIPTION
Sync branch is only for sync action. We shouldn't backup it to gitlab
or gitee. Just add -nosync suffix to let backup action ignore it.

Log: do not synchronize sync branch
